### PR TITLE
Cleanup home controller

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,14 +1,4 @@
 class HomeController < ApplicationController
-
-  # I think this gets around these functions being private? Not sure.
-  helper_method :artist_logged_in?, :voter_logged_in?, :verified_voter_logged_in?, :admin_logged_in?
-
-  #before_filter artist_logged_in?, except: [:show, :index]
-
   def index
   end
-
-  def hello
-  end
-
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,7 @@
 Rails.application.routes.draw do
   mount Judge::Engine => '/judge'
 
-  get 'home/index'
-  root 'home#index'
+  root to: 'home#index'
 
   get 'password_resets/' => 'password_resets#index'
   get 'password_resets/new'


### PR DESCRIPTION
Removes unused code from HomeController and uses `root to:` directive in `config/routes.rb`. The HomeController already has spces.