### PR TITLE
Admins controller cleanup

### DIFF
--- a/app/controllers/admins/grant_submissions_controller.rb
+++ b/app/controllers/admins/grant_submissions_controller.rb
@@ -30,4 +30,61 @@ class Admins::GrantSubmissionsController < ApplicationController
       @grant_submissions = @grant_submissions.to_a.sort_by { |gs| gs.name }
     end
   end
+
+  def send_fund_emails
+    ids = params[:ids]&.split(',') || []
+    @grant_submissions = GrantSubmission.where(id: ids)
+
+    sent = 0
+    @grant_submissions.each do |gs|
+      if params[:send_email] == "true"
+        artist = Artist.where(id: gs.artist_id).take
+        grant = Grant.where(id: gs.grant_id).take
+        begin
+          if gs.granted_funding_dollars == 0
+            UserMailer.grant_not_funded(gs, artist, grant, event_year).deliver
+            logger.info "email: grant not funded sent to #{artist.email}"
+          else
+            UserMailer.grant_funded(gs, artist, grant, event_year).deliver
+            logger.info "email: grant funded sent to #{artist.email}"
+          end
+        rescue
+          flash[:warning] = "Error sending email (#{sent} sent)"
+          redirect_to action: 'index'
+          return
+        end
+        sent += 1
+      end
+      gs.funding_decision = true
+      gs.save
+    end
+
+    flash[:info] = "#{sent} Funding Emails Sent"
+    redirect_to action: 'index'
+  end
+
+  def send_question_emails
+    @grant_submissions = GrantSubmission.where(grant_id: active_vote_grants)
+
+    sent = 0
+    @grant_submissions.each do |gs|
+      if gs.questions != nil && gs.has_questions?
+        artist = Artist.where(id: gs.artist_id).take
+        grant = Grant.where(id: gs.grant_id).take
+        begin
+          UserMailer.notify_questions(gs, artist, grant, event_year).deliver
+          logger.info "email: questions notification sent to #{artist.email}"
+        rescue
+          flash[:warning] = "Error sending emails (#{sent} sent)"
+          redirect_to action: 'index'
+          return
+        end
+        sent += 1
+      end
+    end
+
+    flash[:info] = "#{sent} Question Notification Emails Sent"
+    redirect_to action: 'index'
+  end
+
 end

--- a/app/controllers/admins_controller.rb
+++ b/app/controllers/admins_controller.rb
@@ -2,7 +2,6 @@ class AdminsController < ApplicationController
   load_and_authorize_resource
 
   before_filter :init_admin
-  before_filter :init_artists
   before_filter :verify_admin
 
   def index
@@ -132,9 +131,5 @@ class AdminsController < ApplicationController
 
   def init_admin
     @admin = Admin.new
-  end
-
-  def init_artists
-    @artists = Artist.all
   end
 end

--- a/app/controllers/admins_controller.rb
+++ b/app/controllers/admins_controller.rb
@@ -97,10 +97,6 @@ class AdminsController < ApplicationController
     end
   end
 
-  # TODO: endpoint does not belong here
-  def voters
-  end
-
   private
 
   def admin_params

--- a/app/controllers/admins_controller.rb
+++ b/app/controllers/admins_controller.rb
@@ -3,7 +3,7 @@ class AdminsController < ApplicationController
 
   before_filter :init_admin
   before_filter :init_artists
-  before_filter :verify_admin, except: [:index, :new, :create, :verify]
+  before_filter :verify_admin
 
   def index
     @verified_voters = Voter.where(verified: true)

--- a/app/controllers/admins_controller.rb
+++ b/app/controllers/admins_controller.rb
@@ -3,10 +3,10 @@ class AdminsController < ApplicationController
 
   before_filter :init_admin
   before_filter :init_artists
-  before_filter :init_voters
   before_filter :verify_admin, except: [:index, :new, :create, :verify]
 
   def index
+    @verified_voters = Voter.where(verified: true)
   end
 
   def new
@@ -136,24 +136,5 @@ class AdminsController < ApplicationController
 
   def init_artists
     @artists = Artist.all
-  end
-
-  def init_voters
-    @voters = Voter.all
-    @verified_voters = Voter.where(verified: true)
-    # builds a run-time array to map assignments to voters for easy display
-    @verified_voters.each do |vv|
-      vv.class_eval do
-        attr_accessor :assigned
-      end
-
-      vv.assigned = Array.new
-      VoterSubmissionAssignment.where("voter_id = ?",vv.id).each do |vsa|
-        gs = GrantSubmission.find_by_id(vsa.grant_submission_id)
-        if gs != nil
-          vv.assigned.push("#{gs.name}(#{gs.id})")
-        end
-      end
-    end
   end
 end

--- a/app/controllers/admins_controller.rb
+++ b/app/controllers/admins_controller.rb
@@ -1,7 +1,6 @@
 class AdminsController < ApplicationController
   load_and_authorize_resource
 
-  before_filter :init_admin
   before_filter :verify_admin
 
   def index
@@ -127,9 +126,5 @@ class AdminsController < ApplicationController
       end
     end
     return fewest
-  end
-
-  def init_admin
-    @admin = Admin.new
   end
 end

--- a/app/controllers/admins_controller.rb
+++ b/app/controllers/admins_controller.rb
@@ -1,5 +1,5 @@
 class AdminsController < ApplicationController
-  load_and_authorize_resource only: [:index, :new, :create]
+  load_and_authorize_resource
 
   before_filter :init_admin
   before_filter :init_artists

--- a/app/views/admins/grant_submissions/index.html.erb
+++ b/app/views/admins/grant_submissions/index.html.erb
@@ -110,7 +110,7 @@
   </tr>
   <tr>
     <td colspan="<%= colspan %>" align="right"><b>Sends emails to artists with non-empty Questions</b></td>
-    <td><%= button_to "Notify Questions", admins_send_question_emails_path, class: 'btn btn-warning' %></td>
+    <td><%= button_to "Notify Questions", send_question_emails_admins_grant_submissions_path, class: 'btn btn-warning' %></td>
   </tr>
   </tfoot>
   <% end %>
@@ -148,7 +148,7 @@ function confirm_selected(event) {
   }
   var send_email = document.getElementById('send_grant_fund_email_checkbox').checked;
   var admin_js = '<%= raw @admin.to_json %>';
-  $.post("/admins/send_fund_emails?ids=" + selected + "&send_email=" + send_email,
+  $.post("<%= escape_javascript(send_fund_emails_admins_grant_submissions_path) %>?ids=" + selected + "&send_email=" + send_email,
       {"admin": admin_js});
   return false;
 }

--- a/app/views/admins/grant_submissions/index.html.erb
+++ b/app/views/admins/grant_submissions/index.html.erb
@@ -147,9 +147,7 @@ function confirm_selected(event) {
     return false;
   }
   var send_email = document.getElementById('send_grant_fund_email_checkbox').checked;
-  var admin_js = '<%= raw @admin.to_json %>';
-  $.post("<%= escape_javascript(send_fund_emails_admins_grant_submissions_path) %>?ids=" + selected + "&send_email=" + send_email,
-      {"admin": admin_js});
+  $.post("<%= escape_javascript(send_fund_emails_admins_grant_submissions_path) %>?ids=" + selected + "&send_email=" + send_email);
   return false;
 }
 </script>

--- a/app/views/admins/index.html.erb
+++ b/app/views/admins/index.html.erb
@@ -23,17 +23,39 @@
         <thead>
         <tr>
           <th>Name</th>
-          <th>Email</th>
+          <th>Grants</th>
           <th>Assigned</th>
         </tr>
         </thead>
         <tbody>
-        <% @verified_voters.each do |vv| %>
+        <% @verified_voters.each do |voter| %>
         <tr>
-          <td><%= vv.name %></td>
-          <td><%= vv.email %></td>
           <td>
-            <%= vv.grant_submissions.map { |gs| "#{gs.name}(#{gs.id})" }.join(', ').html_safe %>
+            <% if can? :edit, voter %>
+              <%= link_to voter.name, voter_path(voter) %>
+            <% else %>
+              <%= voter.name %>
+            <% end %>
+            <br />
+            <%= voter.email %>
+          </td>
+          <td>
+            <% if voter.grants.count > 0 %>
+              <%= voter.grants.pluck(:name).join(", ") %>
+            <% else %>
+              <em>None</em>
+            <% end %>
+          </td>
+          <td>
+            <% if voter.grant_submissions.count > 0 %>
+            <ul class="list-unstyled">
+              <% voter.grant_submissions.map do |grant_submission| %>
+                <li><%= "#{grant_submission.name}(##{grant_submission.id})" %></li>
+              <% end %>
+            </ul>
+            <% else %>
+              <em>None</em>
+            <% end %>
           </td>
         </tr>
         <% end %>

--- a/app/views/admins/index.html.erb
+++ b/app/views/admins/index.html.erb
@@ -17,7 +17,7 @@
 <% if any_vote_open? %>
   <div class="panel panel-default">
     <div class="panel-heading">
-      <h3 class="panel-title">Assignments</h3>
+      <h3 class="panel-title">Verified Voter Assignments</h3>
     </div>
       <table class="table">
         <thead>
@@ -32,7 +32,9 @@
         <tr>
           <td><%= vv.name %></td>
           <td><%= vv.email %></td>
-          <td><%= vv.assigned.join(', ').html_safe %></td>
+          <td>
+            <%= vv.grant_submissions.map { |gs| "#{gs.name}(#{gs.id})" }.join(', ').html_safe %>
+          </td>
         </tr>
         <% end %>
         </tbody>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,15 +13,17 @@ Rails.application.routes.draw do
 
   post 'admins/assign' => 'admins#assign'
   post 'admins/clear_assignments' => 'admins#clear_assignments'
-  post 'admins/send_fund_emails' => 'admins#send_fund_emails'
-  post 'admins/send_question_emails' => 'admins#send_question_emails'
-
   resources :artists, :grant_submissions
   resources :grants, except: [:show]
 
   resources :admins, only: [:new, :create, :index]
   namespace :admins do
-    resources :grant_submissions, only: [:index]
+    resources :grant_submissions, only: [:index] do
+      collection do
+        post 'send_fund_emails'
+        post 'send_question_emails'
+      end
+    end
   end
 
   resources :grant_submissions do

--- a/spec/controllers/admins/grant_submissions_controller_spec.rb
+++ b/spec/controllers/admins/grant_submissions_controller_spec.rb
@@ -20,4 +20,52 @@ describe Admins::GrantSubmissionsController do
       end
     end
   end
+
+  describe '#send_fund_emails' do
+    def go!
+      post 'send_fund_emails'
+    end
+
+    context 'logged out' do
+      it 'is forbidden' do
+        go!
+        expect(response).to be_forbidden
+      end
+    end
+
+    context 'logged in' do
+      let!(:admin) { FactoryGirl.create(:admin) }
+
+      before do
+        sign_in_admin(admin.id)
+        go!
+      end
+
+      it { is_expected.to be_ok }
+    end
+  end
+
+  describe '#send_question_emails' do
+    def go!
+      post 'send_question_emails'
+    end
+
+    context 'logged out' do
+      it 'is forbidden' do
+        go!
+        expect(response).to be_forbidden
+      end
+    end
+
+    context 'logged in' do
+      let!(:admin) { FactoryGirl.create(:admin) }
+
+      before do
+        sign_in_admin(admin.id)
+        go!
+      end
+
+      it { is_expected.to be_ok }
+    end
+  end
 end

--- a/spec/controllers/admins_controller_spec.rb
+++ b/spec/controllers/admins_controller_spec.rb
@@ -108,7 +108,7 @@ describe AdminsController do
     end
   end
 
-  xdescribe '#assign' do
+  describe '#assign' do
     def go!
       post 'assign'
     end

--- a/spec/controllers/admins_controller_spec.rb
+++ b/spec/controllers/admins_controller_spec.rb
@@ -84,7 +84,31 @@ describe AdminsController do
     end
   end
 
-  describe '#assign' do
+  describe '#clear_assignments' do
+    def go!
+      post 'clear_assignments'
+    end
+
+    context 'logged out' do
+      it 'is forbidden' do
+        go!
+        expect(response).to be_forbidden
+      end
+    end
+
+    context 'logged in' do
+      let!(:admin) { FactoryGirl.create(:admin) }
+
+      before do
+        sign_in_admin(admin.id)
+        go!
+      end
+
+      it { is_expected.to be_ok }
+    end
+  end
+
+  xdescribe '#assign' do
     def go!
       post 'assign'
     end


### PR DESCRIPTION
* Move `AdminsController#send_fund_emails` and `AdminsController#send_question_emails` to `Admins::GrantController`
* Run load_and_authorize_resource and verify_admin for all `AdminsController` endpoints
* Remove unused `AdminsController` methods such as `init_admin`, `init_artist`, `init_voters`
* Add smoke tests for `AdminsController` and `Admins::GrantController`
* Improve display of voter assignments
![screen shot 2017-04-06 at 12 07 36 pm](https://cloud.githubusercontent.com/assets/80069/24764229/adef76ea-1ac1-11e7-8006-ba5fb9e952a8.png)
