### PR TITLE
Migrate app to run inside a docker container

### DIFF
--- a/.github/workflows/docker-deploy.yml
+++ b/.github/workflows/docker-deploy.yml
@@ -4,7 +4,7 @@ name: Create and publish a Docker image
 # Configures this workflow to run every time a change is pushed to the branch called `release`.
 on:
   push:
-    branches: ['docker']
+    branches: ['docker','main']
 
 # Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.
 env:

--- a/.github/workflows/docker-deploy.yml
+++ b/.github/workflows/docker-deploy.yml
@@ -1,0 +1,61 @@
+#
+name: Create and publish a Docker image
+
+# Configures this workflow to run every time a change is pushed to the branch called `release`.
+on:
+  push:
+    branches: ['docker']
+
+# Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+# There is a single job in this workflow. It's configured to run on the latest available version of Ubuntu.
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+      # 
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about) to extract tags and labels that will be applied to the specified image. The `id` "meta" allows the output of this step to be referenced in a subsequent step. The `images` value provides the base name for the tags and labels.
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
+      # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
+      # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+      
+      # This step generates an artifact attestation for the image, which is an unforgeable statement about where and how it was built. It increases supply chain security for people who consume the image. For more information, see "[AUTOTITLE](/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds)." 
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true
+      
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,10 +54,15 @@ RUN apt-get update && \
 
 # Make sure Bundler knows where we're placing our gems coming from
 # the build stage.
+
 RUN bundle config set --local path "vendor/bundle"
 
 # Copy everything from the build stage, including gems and precompiled assets.
 COPY --from=build /app /app/
+
+# switch user
+RUN chown -R www-data:www-data /app
+USER www-data:www-data
 
 EXPOSE 3000
 CMD ["bundle", "exec", "rails", "s", "-p", "3000"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,7 @@ RUN bundle config set --local path "vendor/bundle" && \
 # Precompile app assets as the final step.
 COPY . /app/
 RUN bin/rails assets:precompile
+RUN chown -R www-data:www-data /app
 
 #####################################################################
 # Stage 2: Copy gems and assets from build stage and finalize image.
@@ -57,12 +58,11 @@ RUN apt-get update && \
 
 RUN bundle config set --local path "vendor/bundle"
 
+# switch user
+USER www-data:www-data
+
 # Copy everything from the build stage, including gems and precompiled assets.
 COPY --from=build /app /app/
-
-# switch user
-RUN chown -R www-data:www-data /app
-USER www-data:www-data
 
 EXPOSE 3000
 CMD ["bundle", "exec", "rails", "s", "-p", "3000"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,63 @@
+# #####################################################################
+# # Stage 1: Install gems and precompile assets.
+# #####################################################################
+FROM ruby:3.3-slim AS build
+WORKDIR /app
+
+# Set a random secret key base so we can precompile assets.
+ENV SECRET_KEY_BASE airport_gap_secret_key_base
+
+# Install necessary dependencies to set up Node.js and Yarn repos.
+RUN apt-get update && \
+  apt-get install -y --no-install-recommends \
+  curl \
+  gnupg \
+  build-essential \
+  libpq-dev
+
+# Set up Node.js and Yarn package repositories.
+RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash -
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
+RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+
+# Install necessary packages to build gems and assets.
+RUN apt-get update && \
+  apt-get install -y --no-install-recommends \
+  nodejs \
+  yarn
+
+# Install gems into the vendor/bundle directory in the workspace.
+COPY Gemfile Gemfile.lock /app/
+RUN bundle config set --local path "vendor/bundle" && \
+  bundle install --jobs 4 --retry 3
+
+# Install JavaScript dependencies to precompile assets.
+# COPY package.json yarn.lock /app/
+# RUN yarn install
+
+# Precompile app assets as the final step.
+COPY . /app/
+RUN bin/rails assets:precompile
+
+#####################################################################
+# Stage 2: Copy gems and assets from build stage and finalize image.
+#####################################################################
+FROM ruby:3.3-slim
+WORKDIR /app
+
+# Install necessary dependencies required to run the Rails application.
+RUN apt-get update && \
+  apt-get install -y --no-install-recommends \
+  libpq-dev \
+  curl && \
+  rm -rf /var/lib/apt/lists/*
+
+# Make sure Bundler knows where we're placing our gems coming from
+# the build stage.
+RUN bundle config set --local path "vendor/bundle"
+
+# Copy everything from the build stage, including gems and precompiled assets.
+COPY --from=build /app /app/
+
+EXPOSE 3000
+CMD ["bundle", "exec", "rails", "s", "-p", "3000"]

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,6 @@ gem "sprockets-rails"
 gem 'sprockets'
 
 # See https://github.com/sstephenson/execjs#readme for more supported runtimes
-gem 'therubyracer'
 gem 'execjs'
 
 # Use SCSS for stylesheets

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -372,9 +372,6 @@ GEM
       mini_portile2 (~> 2.8.0)
     ssrf_filter (1.2.0)
     stringio (3.1.2)
-    therubyracer (0.12.3)
-      libv8 (~> 3.16.14.15)
-      ref
     thor (1.3.2)
     tilt (2.5.0)
     timecop (0.9.10)
@@ -440,7 +437,6 @@ DEPENDENCIES
   sprockets
   sprockets-rails
   sqlite3
-  therubyracer
   timecop
   turbolinks
   uglifier (>= 1.3.0)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -131,8 +131,8 @@ Rails.application.configure do
   config.action_mailer.delivery_method = :smtp
 
   config.action_mailer.smtp_settings = {
-    address:              Rails.application.secrets.smtp['address'],
-    port:                 Rails.application.secrets.smtp['port'],
-    domain:               Rails.application.secrets.smtp['domain']
+    address:              ENV['SMTP_ADDRESS'],
+    port:                 ENV['SMTP_PORT'],
+    domain:               (ENV['SMTP_DOMAIN']).to_i
   }
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -122,6 +122,7 @@ Rails.application.configure do
   # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
 
   # Prod email settings
+  config.action_mailer.logger = ActiveSupport::Logger.new("log/mailer.log")
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.perform_deliveries = true
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -128,5 +128,6 @@ Rails.application.configure do
   # This is the hostname that will be used in links inside emails
   config.action_mailer.default_url_options = { :host => 'grants.fireflyartscollective.org' }
 
-  config.action_mailer.delivery_method = :sendmail
+  # don't use sendmail while on docker
+  # config.action_mailer.delivery_method = :sendmail
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -128,6 +128,11 @@ Rails.application.configure do
   # This is the hostname that will be used in links inside emails
   config.action_mailer.default_url_options = { :host => 'grants.fireflyartscollective.org' }
 
-  # don't use sendmail while on docker
-  # config.action_mailer.delivery_method = :sendmail
+  config.action_mailer.delivery_method = :smtp
+
+  config.action_mailer.smtp_settings = {
+    address:              Rails.application.secrets.smtp['address'],
+    port:                 Rails.application.secrets.smtp['port'],
+    domain:               Rails.application.secrets.smtp['domain']
+  }
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -134,6 +134,7 @@ Rails.application.configure do
   config.action_mailer.smtp_settings = {
     address:              ENV['SMTP_ADDRESS'],
     port:                 ENV['SMTP_PORT'],
-    domain:               (ENV['SMTP_DOMAIN']).to_i
+    domain:               (ENV['SMTP_DOMAIN']).to_i,
+    openssl_verify_mode:  OpenSSL::SSL::VERIFY_NONE
   }
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+services:
+  app:
+    image: ghcr.io/fireflyartscollective/ffagc:docker
+    restart: unless-stopped
+    volumes:
+      - /var/www/ffagc/.env:/app/.env
+      - /var/www/ffagc/public/uploads:/app/public/uploads
+      - /var/www/ffagc/db:/app/db
+    ports:
+      - '3000:3000'
+    environment:
+      - RAILS_ENV=production
+


### PR DESCRIPTION
- Add Dockerfile and docker-compose
- Use SMTP for production instead of sendmail (unavailable in a docker container)
- Remove therubyracer, an ancient/deprecated javascript runtime that won't build on python3, replace with node.js
- Add github actions build workflow